### PR TITLE
feat(dashboard): multi-select type filter, sort toggle, and test DB isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ dashboard/node_modules
 dashboard/dist
 .reactotron-llm
 .reactotron-llm/
+.reactotron-llm-test
+.reactotron-llm-test/
 .env
 .env.*
 !.env.example

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -26,6 +26,7 @@ import FilterBar from './components/FilterBar'
 import SessionCompare from './components/SessionCompare'
 import SessionDetail from './components/SessionDetail'
 import SessionTree from './components/SessionTree'
+import { useEventFilter } from './hooks/useEventFilter'
 
 type EventsResponse = {
   ok: boolean
@@ -105,13 +106,23 @@ export default function App() {
   const [hasMore, setHasMore] = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
   const [serverLoadedCount, setServerLoadedCount] = useState(0)
-  const [typeFilter, setTypeFilter] = useState('')
-  const [levelFilter, setLevelFilter] = useState('')
-  const [urlFilter, setUrlFilter] = useState('')
-  const [errorsOnly, setErrorsOnly] = useState(false)
   const [viewState, setViewState] = useState<ViewState>({ tab: 'live' })
   const [compareMode, setCompareMode] = useState(false)
   const [selectedForCompare, setSelectedForCompare] = useState<Set<string>>(new Set())
+
+  const {
+    typeFilter,
+    levelFilter,
+    urlFilter,
+    errorsOnly,
+    eventTypes,
+    filteredEvents,
+    setTypeFilter,
+    setLevelFilter,
+    setUrlFilter,
+    setErrorsOnly,
+    resetFilters,
+  } = useEventFilter(events)
 
   const tabIndex = viewState.tab === 'live' ? 0 : 1
 
@@ -166,6 +177,7 @@ export default function App() {
   async function resetEvents() {
     await fetch(`${apiBase}/api/events/reset`, { method: 'POST' })
     setEvents([])
+    resetFilters()
   }
 
   useEffect(() => {
@@ -189,6 +201,7 @@ export default function App() {
         }
         if (parsed.kind === 'events-reset') {
           setEvents([])
+          resetFilters()
         }
         if (parsed.kind === 'state-updated') {
           loadState().catch(() => undefined)
@@ -203,24 +216,6 @@ export default function App() {
 
   const errorCount = useMemo(() => events.filter((event) => event.level === 'error').length, [events])
   const networkCount = useMemo(() => events.filter((event) => event.network !== undefined).length, [events])
-  const eventTypes = useMemo(
-    () => Array.from(new Set(events.map((event) => event.type))).sort((a, b) => a.localeCompare(b)),
-    [events],
-  )
-  const filteredEvents = useMemo(() => {
-    return [...events]
-      .filter((event) => {
-      if (errorsOnly && event.level !== 'error') return false
-      if (typeFilter && event.type !== typeFilter) return false
-      if (levelFilter && (event.level ?? '') !== levelFilter) return false
-      if (urlFilter) {
-        const url = (event.network?.url ?? '').toLowerCase()
-        if (!url.includes(urlFilter.toLowerCase())) return false
-      }
-      return true
-      })
-      .sort(byNewest)
-  }, [errorsOnly, events, levelFilter, typeFilter, urlFilter])
 
   const isSessionDetail = viewState.tab === 'history' && viewState.view === 'session'
   const isCompareView = viewState.tab === 'history' && viewState.view === 'compare'
@@ -276,7 +271,7 @@ export default function App() {
                   isDisabled={events.length === 0}
                   onClick={() => {
                     const params = new URLSearchParams()
-                    if (typeFilter) params.set('type', typeFilter)
+                    if (typeFilter.size > 0) params.set('type', Array.from(typeFilter).join(','))
                     if (levelFilter) params.set('level', levelFilter)
                     else if (errorsOnly) params.set('level', 'error')
                     const qs = params.toString()
@@ -372,12 +367,7 @@ export default function App() {
               onLevelFilterChange={setLevelFilter}
               onUrlFilterChange={setUrlFilter}
               onErrorsOnlyChange={setErrorsOnly}
-              onReset={() => {
-                setTypeFilter('')
-                setLevelFilter('')
-                setUrlFilter('')
-                setErrorsOnly(false)
-              }}
+              onReset={resetFilters}
             />
 
             <Grid templateColumns={{ base: '1fr', lg: '3fr 2fr' }} gap={4} minW={0}>

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -115,12 +115,14 @@ export default function App() {
     levelFilter,
     urlFilter,
     errorsOnly,
+    sortOrder,
     eventTypes,
     filteredEvents,
     setTypeFilter,
     setLevelFilter,
     setUrlFilter,
     setErrorsOnly,
+    toggleSortOrder,
     resetFilters,
   } = useEventFilter(events)
 
@@ -362,11 +364,13 @@ export default function App() {
               levelFilter={levelFilter}
               urlFilter={urlFilter}
               errorsOnly={errorsOnly}
+              sortOrder={sortOrder}
               eventTypes={eventTypes}
               onTypeFilterChange={setTypeFilter}
               onLevelFilterChange={setLevelFilter}
               onUrlFilterChange={setUrlFilter}
               onErrorsOnlyChange={setErrorsOnly}
+              onSortOrderToggle={toggleSortOrder}
               onReset={resetFilters}
             />
 

--- a/dashboard/src/components/FilterBar.tsx
+++ b/dashboard/src/components/FilterBar.tsx
@@ -6,6 +6,7 @@ import {
   CheckboxGroup,
   HStack,
   Heading,
+  IconButton,
   Input,
   Popover,
   PopoverBody,
@@ -13,21 +14,25 @@ import {
   PopoverTrigger,
   Select,
   Text,
+  Tooltip,
   VStack,
   useDisclosure,
 } from '@chakra-ui/react'
-import { ChevronDownIcon } from '@chakra-ui/icons'
+import { ChevronDownIcon, TriangleDownIcon, TriangleUpIcon } from '@chakra-ui/icons'
+import type { SortOrder } from '../hooks/useEventFilter'
 
 type FilterBarProps = {
   typeFilter: Set<string>
   levelFilter: string
   urlFilter: string
   errorsOnly: boolean
+  sortOrder: SortOrder
   eventTypes: string[]
   onTypeFilterChange: (value: Set<string>) => void
   onLevelFilterChange: (value: string) => void
   onUrlFilterChange: (value: string) => void
   onErrorsOnlyChange: (value: boolean) => void
+  onSortOrderToggle: () => void
   onReset: () => void
 }
 
@@ -42,11 +47,13 @@ export default function FilterBar({
   levelFilter,
   urlFilter,
   errorsOnly,
+  sortOrder,
   eventTypes,
   onTypeFilterChange,
   onLevelFilterChange,
   onUrlFilterChange,
   onErrorsOnlyChange,
+  onSortOrderToggle,
   onReset,
 }: FilterBarProps) {
   const { isOpen, onToggle, onClose } = useDisclosure()
@@ -162,6 +169,16 @@ export default function FilterBar({
         <Checkbox isChecked={errorsOnly} onChange={(e) => onErrorsOnlyChange(e.target.checked)} pb={1}>
           Errors only
         </Checkbox>
+        <Tooltip label={sortOrder === 'newest' ? 'Showing newest first' : 'Showing oldest first'} placement="top">
+          <IconButton
+            aria-label={`Sort ${sortOrder === 'newest' ? 'oldest' : 'newest'} first`}
+            icon={sortOrder === 'newest' ? <TriangleDownIcon /> : <TriangleUpIcon />}
+            size="sm"
+            variant="subtle"
+            onClick={onSortOrderToggle}
+            data-testid="sort-order-toggle"
+          />
+        </Tooltip>
         <Button size="sm" variant="subtle" onClick={onReset}>
           Reset
         </Button>

--- a/dashboard/src/components/FilterBar.tsx
+++ b/dashboard/src/components/FilterBar.tsx
@@ -1,25 +1,40 @@
+import { useRef } from 'react'
 import {
   Box,
   Button,
   Checkbox,
+  CheckboxGroup,
   HStack,
   Heading,
   Input,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   Text,
+  VStack,
+  useDisclosure,
 } from '@chakra-ui/react'
+import { ChevronDownIcon } from '@chakra-ui/icons'
 
 type FilterBarProps = {
-  typeFilter: string
+  typeFilter: Set<string>
   levelFilter: string
   urlFilter: string
   errorsOnly: boolean
   eventTypes: string[]
-  onTypeFilterChange: (value: string) => void
+  onTypeFilterChange: (value: Set<string>) => void
   onLevelFilterChange: (value: string) => void
   onUrlFilterChange: (value: string) => void
   onErrorsOnlyChange: (value: boolean) => void
   onReset: () => void
+}
+
+function typeFilterLabel(typeFilter: Set<string>): string {
+  if (typeFilter.size === 0) return 'All'
+  if (typeFilter.size <= 2) return Array.from(typeFilter).join(', ')
+  return `${typeFilter.size} types selected`
 }
 
 export default function FilterBar({
@@ -34,18 +49,101 @@ export default function FilterBar({
   onErrorsOnlyChange,
   onReset,
 }: FilterBarProps) {
+  const { isOpen, onToggle, onClose } = useDisclosure()
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  function toggleType(type: string) {
+    const next = new Set(typeFilter)
+    if (next.has(type)) {
+      next.delete(type)
+    } else {
+      next.add(type)
+    }
+    onTypeFilterChange(next)
+  }
+
+  function selectAll() {
+    onTypeFilterChange(new Set(eventTypes))
+  }
+
+  function clearAll() {
+    onTypeFilterChange(new Set())
+  }
+
+  const allSelected = eventTypes.length > 0 && typeFilter.size === eventTypes.length
+
   return (
     <Box p={4} borderWidth="1px" borderColor="gray.700" borderRadius="lg" bg="gray.900">
       <Heading size="sm" mb={3}>Filters</Heading>
       <HStack align="end" spacing={3} wrap="wrap" minW={0}>
         <Box minW="220px">
           <Text fontSize="sm" mb={1}>Type</Text>
-          <Select value={typeFilter} onChange={(e) => onTypeFilterChange(e.target.value)}>
-            <option value="">All</option>
-            {eventTypes.map((type) => (
-              <option key={type} value={type}>{type}</option>
-            ))}
-          </Select>
+          <Popover isOpen={isOpen} onClose={onClose} placement="bottom-start" isLazy>
+            <PopoverTrigger>
+              <Button
+                ref={triggerRef}
+                variant="outline"
+                size="md"
+                w="100%"
+                justifyContent="space-between"
+                rightIcon={<ChevronDownIcon />}
+                fontWeight="normal"
+                borderColor="gray.600"
+                color={typeFilter.size > 0 ? 'gray.100' : 'gray.300'}
+                _hover={{ borderColor: 'gray.500' }}
+                onClick={onToggle}
+                data-testid="type-filter-trigger"
+              >
+                <Text noOfLines={1} textAlign="left">
+                  {typeFilterLabel(typeFilter)}
+                </Text>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              bg="gray.900"
+              borderColor="gray.600"
+              w={triggerRef.current ? `${triggerRef.current.offsetWidth}px` : '220px'}
+            >
+              <PopoverBody p={0}>
+                <HStack justify="space-between" px={3} py={2} borderBottomWidth="1px" borderColor="gray.700">
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    color="reactotron.400"
+                    onClick={allSelected ? clearAll : selectAll}
+                  >
+                    {allSelected ? 'Clear' : 'Select All'}
+                  </Button>
+                </HStack>
+                <CheckboxGroup value={Array.from(typeFilter)}>
+                  <VStack
+                    align="stretch"
+                    spacing={0}
+                    maxH="240px"
+                    overflowY="auto"
+                    px={3}
+                    py={2}
+                  >
+                    {eventTypes.map((type) => (
+                      <Checkbox
+                        key={type}
+                        value={type}
+                        isChecked={typeFilter.has(type)}
+                        onChange={() => toggleType(type)}
+                        colorScheme="reactotron"
+                        py={1}
+                      >
+                        <Text fontSize="sm">{type}</Text>
+                      </Checkbox>
+                    ))}
+                    {eventTypes.length === 0 ? (
+                      <Text fontSize="sm" color="gray.500" py={1}>No event types</Text>
+                    ) : null}
+                  </VStack>
+                </CheckboxGroup>
+              </PopoverBody>
+            </PopoverContent>
+          </Popover>
         </Box>
         <Box minW="180px">
           <Text fontSize="sm" mb={1}>Level</Text>

--- a/dashboard/src/components/SessionDetail.tsx
+++ b/dashboard/src/components/SessionDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Badge,
   Box,
@@ -21,6 +21,7 @@ import type { CuratedEvent } from '@shared/types'
 import type { SessionStats } from '@shared/types'
 import EventCard from './EventCard'
 import FilterBar from './FilterBar'
+import { useEventFilter } from '../hooks/useEventFilter'
 
 type SessionEventsResponse = {
   ok: boolean
@@ -80,10 +81,19 @@ export default function SessionDetail({ apiBase, sessionId, onBack, onCompareWit
   const [meta, setMeta] = useState<SessionResponse['session'] | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [typeFilter, setTypeFilter] = useState('')
-  const [levelFilter, setLevelFilter] = useState('')
-  const [urlFilter, setUrlFilter] = useState('')
-  const [errorsOnly, setErrorsOnly] = useState(false)
+  const {
+    typeFilter,
+    levelFilter,
+    urlFilter,
+    errorsOnly,
+    eventTypes,
+    filteredEvents,
+    setTypeFilter,
+    setLevelFilter,
+    setUrlFilter,
+    setErrorsOnly,
+    resetFilters,
+  } = useEventFilter(events)
 
   async function loadSession() {
     setLoading(true)
@@ -132,23 +142,6 @@ export default function SessionDetail({ apiBase, sessionId, onBack, onCompareWit
     loadSession().catch(() => undefined)
   }, [sessionId, apiBase])
 
-  const eventTypes = useMemo(
-    () => Array.from(new Set(events.map((e) => e.type))).sort((a, b) => a.localeCompare(b)),
-    [events],
-  )
-
-  const filteredEvents = useMemo(() => {
-    return events.filter((event) => {
-      if (errorsOnly && event.level !== 'error') return false
-      if (typeFilter && event.type !== typeFilter) return false
-      if (levelFilter && (event.level ?? '') !== levelFilter) return false
-      if (urlFilter) {
-        const url = (event.network?.url ?? '').toLowerCase()
-        if (!url.includes(urlFilter.toLowerCase())) return false
-      }
-      return true
-    })
-  }, [errorsOnly, events, levelFilter, typeFilter, urlFilter])
 
   if (loading) {
     return (
@@ -301,12 +294,7 @@ export default function SessionDetail({ apiBase, sessionId, onBack, onCompareWit
         onLevelFilterChange={setLevelFilter}
         onUrlFilterChange={setUrlFilter}
         onErrorsOnlyChange={setErrorsOnly}
-        onReset={() => {
-          setTypeFilter('')
-          setLevelFilter('')
-          setUrlFilter('')
-          setErrorsOnly(false)
-        }}
+        onReset={resetFilters}
       />
 
       {filteredEvents.length === 0 ? (

--- a/dashboard/src/components/SessionDetail.tsx
+++ b/dashboard/src/components/SessionDetail.tsx
@@ -86,12 +86,14 @@ export default function SessionDetail({ apiBase, sessionId, onBack, onCompareWit
     levelFilter,
     urlFilter,
     errorsOnly,
+    sortOrder,
     eventTypes,
     filteredEvents,
     setTypeFilter,
     setLevelFilter,
     setUrlFilter,
     setErrorsOnly,
+    toggleSortOrder,
     resetFilters,
   } = useEventFilter(events)
 
@@ -289,11 +291,13 @@ export default function SessionDetail({ apiBase, sessionId, onBack, onCompareWit
         levelFilter={levelFilter}
         urlFilter={urlFilter}
         errorsOnly={errorsOnly}
+        sortOrder={sortOrder}
         eventTypes={eventTypes}
         onTypeFilterChange={setTypeFilter}
         onLevelFilterChange={setLevelFilter}
         onUrlFilterChange={setUrlFilter}
         onErrorsOnlyChange={setErrorsOnly}
+        onSortOrderToggle={toggleSortOrder}
         onReset={resetFilters}
       />
 

--- a/dashboard/src/hooks/useEventFilter.ts
+++ b/dashboard/src/hooks/useEventFilter.ts
@@ -1,0 +1,62 @@
+import { useMemo, useState } from 'react'
+import type { CuratedEvent } from '@shared/types'
+
+export type EventFilterState = {
+  typeFilter: Set<string>
+  levelFilter: string
+  urlFilter: string
+  errorsOnly: boolean
+  eventTypes: string[]
+  filteredEvents: CuratedEvent[]
+  setTypeFilter: (value: Set<string>) => void
+  setLevelFilter: (value: string) => void
+  setUrlFilter: (value: string) => void
+  setErrorsOnly: (value: boolean) => void
+  resetFilters: () => void
+}
+
+export function useEventFilter(events: CuratedEvent[]): EventFilterState {
+  const [typeFilter, setTypeFilter] = useState<Set<string>>(new Set())
+  const [levelFilter, setLevelFilter] = useState('')
+  const [urlFilter, setUrlFilter] = useState('')
+  const [errorsOnly, setErrorsOnly] = useState(false)
+
+  const eventTypes = useMemo(
+    () => Array.from(new Set(events.map((e) => e.type))).sort((a, b) => a.localeCompare(b)),
+    [events],
+  )
+
+  const filteredEvents = useMemo(() => {
+    return events.filter((event) => {
+      if (errorsOnly && event.level !== 'error') return false
+      if (typeFilter.size > 0 && !typeFilter.has(event.type)) return false
+      if (levelFilter && (event.level ?? '') !== levelFilter) return false
+      if (urlFilter) {
+        const url = (event.network?.url ?? '').toLowerCase()
+        if (!url.includes(urlFilter.toLowerCase())) return false
+      }
+      return true
+    })
+  }, [errorsOnly, events, levelFilter, typeFilter, urlFilter])
+
+  function resetFilters() {
+    setTypeFilter(new Set())
+    setLevelFilter('')
+    setUrlFilter('')
+    setErrorsOnly(false)
+  }
+
+  return {
+    typeFilter,
+    levelFilter,
+    urlFilter,
+    errorsOnly,
+    eventTypes,
+    filteredEvents,
+    setTypeFilter,
+    setLevelFilter,
+    setUrlFilter,
+    setErrorsOnly,
+    resetFilters,
+  }
+}

--- a/dashboard/src/hooks/useEventFilter.ts
+++ b/dashboard/src/hooks/useEventFilter.ts
@@ -43,8 +43,11 @@ export function useEventFilter(events: CuratedEvent[]): EventFilterState {
       }
       return true
     })
-    const direction = sortOrder === 'newest' ? -1 : 1
-    return filtered.sort((a, b) => direction * (new Date(a.ts).getTime() - new Date(b.ts).getTime()))
+    // Sort newest-first by timestamp, then reverse for oldest-first.
+    // Using reverse() instead of flipping the comparator ensures events with
+    // equal timestamps (common in rapid bursts) still visibly reorder on toggle.
+    const sorted = [...filtered].sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime())
+    return sortOrder === 'oldest' ? sorted.reverse() : sorted
   }, [errorsOnly, events, levelFilter, sortOrder, typeFilter, urlFilter])
 
   function toggleSortOrder() {

--- a/dashboard/src/hooks/useEventFilter.ts
+++ b/dashboard/src/hooks/useEventFilter.ts
@@ -1,17 +1,22 @@
 import { useMemo, useState } from 'react'
 import type { CuratedEvent } from '@shared/types'
 
+export type SortOrder = 'newest' | 'oldest'
+
 export type EventFilterState = {
   typeFilter: Set<string>
   levelFilter: string
   urlFilter: string
   errorsOnly: boolean
+  sortOrder: SortOrder
   eventTypes: string[]
   filteredEvents: CuratedEvent[]
   setTypeFilter: (value: Set<string>) => void
   setLevelFilter: (value: string) => void
   setUrlFilter: (value: string) => void
   setErrorsOnly: (value: boolean) => void
+  setSortOrder: (value: SortOrder) => void
+  toggleSortOrder: () => void
   resetFilters: () => void
 }
 
@@ -20,6 +25,7 @@ export function useEventFilter(events: CuratedEvent[]): EventFilterState {
   const [levelFilter, setLevelFilter] = useState('')
   const [urlFilter, setUrlFilter] = useState('')
   const [errorsOnly, setErrorsOnly] = useState(false)
+  const [sortOrder, setSortOrder] = useState<SortOrder>('newest')
 
   const eventTypes = useMemo(
     () => Array.from(new Set(events.map((e) => e.type))).sort((a, b) => a.localeCompare(b)),
@@ -27,7 +33,7 @@ export function useEventFilter(events: CuratedEvent[]): EventFilterState {
   )
 
   const filteredEvents = useMemo(() => {
-    return events.filter((event) => {
+    const filtered = events.filter((event) => {
       if (errorsOnly && event.level !== 'error') return false
       if (typeFilter.size > 0 && !typeFilter.has(event.type)) return false
       if (levelFilter && (event.level ?? '') !== levelFilter) return false
@@ -37,13 +43,20 @@ export function useEventFilter(events: CuratedEvent[]): EventFilterState {
       }
       return true
     })
-  }, [errorsOnly, events, levelFilter, typeFilter, urlFilter])
+    const direction = sortOrder === 'newest' ? -1 : 1
+    return filtered.sort((a, b) => direction * (new Date(a.ts).getTime() - new Date(b.ts).getTime()))
+  }, [errorsOnly, events, levelFilter, sortOrder, typeFilter, urlFilter])
+
+  function toggleSortOrder() {
+    setSortOrder((prev) => (prev === 'newest' ? 'oldest' : 'newest'))
+  }
 
   function resetFilters() {
     setTypeFilter(new Set())
     setLevelFilter('')
     setUrlFilter('')
     setErrorsOnly(false)
+    setSortOrder('newest')
   }
 
   return {
@@ -51,12 +64,15 @@ export function useEventFilter(events: CuratedEvent[]): EventFilterState {
     levelFilter,
     urlFilter,
     errorsOnly,
+    sortOrder,
     eventTypes,
     filteredEvents,
     setTypeFilter,
     setLevelFilter,
     setUrlFilter,
     setErrorsOnly,
+    setSortOrder,
+    toggleSortOrder,
     resetFilters,
   }
 }

--- a/docs/plans/2026-03-16-001-feat-multi-select-type-filter-plan.md
+++ b/docs/plans/2026-03-16-001-feat-multi-select-type-filter-plan.md
@@ -1,0 +1,57 @@
+---
+title: "feat: Support multi-select filtering for event types"
+type: feat
+status: completed
+date: 2026-03-16
+---
+
+# feat: Support multi-select filtering for event types
+
+The dashboard Type filter currently allows selecting a single type or "All". Users want to filter by multiple types at once (e.g. show only `api.response` and `state.action.complete` together).
+
+Relates to: [#16](https://github.com/micheleb/reactotron-llm/issues/16)
+
+## Key Decisions
+
+- **Data structure:** `Set<string>` for the type filter state — matches the existing codebase pattern (SessionCompare uses `Set<string>` for multi-selection with toggle logic).
+- **UI approach:** Custom Popover + CheckboxGroup using Chakra v2 primitives — avoids adding a new dependency (`chakra-react-select` / `react-select`), stays consistent with the dashboard's existing component patterns.
+- **"All" semantics:** Empty set = show all events (not "show nothing"). This matches the current behavior where `typeFilter === ''` means "All".
+- **Trigger display:** Show "All" when nothing selected; show comma-separated type names when 1-2 types selected; show "N types selected" when 3+ types selected.
+- **Shared filter logic:** Extract a `useEventFilter` hook to eliminate the duplicated filtering `useMemo` between App.tsx and SessionDetail.tsx.
+- **Server-side:** No changes needed — the export API already supports comma-separated `type` param via `typeParam.split(',')`.
+
+## Acceptance Criteria
+
+- [x] Type filter allows selecting multiple types via a Popover with checkboxes
+- [x] Events matching **any** selected type are shown (OR logic); other filters remain AND-combined
+- [x] Empty selection shows all events (same as current "All" behavior)
+- [x] Trigger button displays: "All" / "log, api.response" (1-2 types) / "3 types selected" (3+)
+- [x] Export button passes comma-separated types to the API (e.g. `?type=log,api.response`)
+- [x] Reset button clears all selected types back to "All"
+- [x] Works identically in both Live view (App.tsx) and History session detail (SessionDetail.tsx)
+- [x] Checkbox list includes a "Select All" / "Clear" toggle at the top
+- [x] Checkbox list has a max height with scroll for long type lists
+- [x] Stale type selections are pruned when the event list is explicitly reset (Reset Logs button)
+- [x] All colors use the centralized Twilight theme from `theme.ts` (`colorScheme="reactotron"` for checkboxes)
+- [x] Existing Playwright test "Export passes type filter to URL" (`tests/export.spec.ts:168`) is updated for multi-select interaction
+- [x] New test: select 2+ types, verify export URL contains comma-separated values
+- [x] New test: select types, click Reset, verify filter returns to "All"
+
+## Files to Change
+
+1. **`dashboard/src/hooks/useEventFilter.ts`** (new) — Extract shared filtering logic from App.tsx and SessionDetail.tsx into a reusable hook. Accepts `events`, returns filtered events + filter state + setters + derived `eventTypes`.
+
+2. **`dashboard/src/components/FilterBar.tsx`** — Replace `<Select>` with Popover + CheckboxGroup. Change `typeFilter: string` → `typeFilter: Set<string>`, `onTypeFilterChange: (value: string) => void` → `onTypeFilterChange: (value: Set<string>) => void`.
+
+3. **`dashboard/src/App.tsx`** — Replace inline filter state/logic with `useEventFilter` hook. Update export URL builder to join selected types with commas.
+
+4. **`dashboard/src/components/SessionDetail.tsx`** — Replace inline filter state/logic with `useEventFilter` hook.
+
+5. **`tests/export.spec.ts`** — Update existing single-type test and add multi-type export test.
+
+## Out of Scope
+
+- Export button for SessionDetail (History view) — not part of this feature
+- Searchable/filterable checkbox list — not needed for v1 (typically 5-15 distinct types)
+- Multi-select for the Level filter — separate enhancement if desired
+- Comma escaping in type names — event types are dot-separated identifiers, not free-form text

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `PORT=${API_PORT} DASHBOARD_WS_PORT=${DASHBOARD_WS_PORT} bun run src/index.ts`,
+      command: `PORT=${API_PORT} DASHBOARD_WS_PORT=${DASHBOARD_WS_PORT} OUTPUT_DIR=.reactotron-llm-test bun run src/index.ts`,
       port: API_PORT,
       reuseExistingServer: !process.env.CI,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ import type { SessionFullRow, SessionListRow } from './db'
 
 const PORT = Number(Bun.env.PORT ?? 9090)
 const DASHBOARD_WS_PORT = Number(Bun.env.DASHBOARD_WS_PORT ?? 9092)
-const OUTPUT_DIR = path.resolve(process.cwd(), '.reactotron-llm')
+const OUTPUT_DIR = path.resolve(process.cwd(), Bun.env.OUTPUT_DIR ?? '.reactotron-llm')
 const DB_PATH = path.join(OUTPUT_DIR, 'reactotron.db')
 const STATE_PATH = path.join(OUTPUT_DIR, 'state.json')
 

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -173,10 +173,14 @@ test.describe('Export button in dashboard', () => {
     ])
     await openDashboard(page)
 
-    // Wait for the type dropdown to have options beyond "All"
-    const typeSelect = page.locator('select').first()
-    await expect(typeSelect.locator('option')).not.toHaveCount(1)
-    await typeSelect.selectOption('log')
+    // Open the type filter popover and select 'log'
+    const trigger = page.getByTestId('type-filter-trigger')
+    await trigger.click()
+    const popover = page.locator('.chakra-popover__content')
+    await popover.waitFor({ state: 'visible' })
+    await popover.getByText('log', { exact: true }).click()
+    // Close the popover by clicking the trigger again
+    await trigger.click()
 
     // Intercept window.open to capture the URL
     await page.evaluate(() => {
@@ -192,6 +196,70 @@ test.describe('Export button in dashboard', () => {
 
     expect(url).toContain('/api/export')
     expect(url).toContain('type=log')
+  })
+
+  test('Export passes multiple types as comma-separated', async ({ page, request }) => {
+    await request.post(`${API_BASE}/api/events/reset`)
+    await seedEvents(page, [
+      { type: 'log', payload: { level: 'info', message: 'multi type test' } },
+      { type: 'api.response', payload: { status: 200, url: '/x', method: 'GET', duration: 10 } },
+      { type: 'state.action.complete', payload: { name: 'setUser' } },
+    ])
+    await openDashboard(page)
+
+    // Open the type filter popover and select multiple types
+    const trigger = page.getByTestId('type-filter-trigger')
+    await trigger.click()
+    const popover = page.locator('.chakra-popover__content')
+    await popover.waitFor({ state: 'visible' })
+    await popover.getByText('log', { exact: true }).click()
+    await popover.getByText('api.response', { exact: true }).click()
+    // Close the popover
+    await trigger.click()
+
+    // Intercept window.open to capture the URL
+    await page.evaluate(() => {
+      ;(window as any).__capturedExportUrl = ''
+      window.open = ((url?: string | URL) => {
+        ;(window as any).__capturedExportUrl = String(url ?? '')
+        return null
+      }) as typeof window.open
+    })
+
+    await page.getByRole('button', { name: /Export/i }).click()
+    const url = await page.evaluate(() => (window as any).__capturedExportUrl)
+
+    expect(url).toContain('/api/export')
+    // Should contain both types comma-separated
+    expect(url).toMatch(/type=.*log/)
+    expect(url).toMatch(/type=.*api\.response/)
+  })
+
+  test('Reset clears type filter back to All', async ({ page, request }) => {
+    await request.post(`${API_BASE}/api/events/reset`)
+    await seedEvents(page, [
+      { type: 'log', payload: { level: 'info', message: 'reset test' } },
+      { type: 'api.response', payload: { status: 200, url: '/x', method: 'GET', duration: 10 } },
+    ])
+    await openDashboard(page)
+
+    // Select a type filter
+    const trigger = page.getByTestId('type-filter-trigger')
+    await trigger.click()
+    const popover = page.locator('.chakra-popover__content')
+    await popover.waitFor({ state: 'visible' })
+    await popover.getByText('log', { exact: true }).click()
+    // Close the popover
+    await trigger.click()
+
+    // Verify the trigger shows the selected type
+    await expect(trigger).toHaveText('log')
+
+    // Click the filter Reset button (not "Reset Logs")
+    await page.getByRole('button', { name: 'Reset', exact: true }).click()
+
+    // Verify the trigger shows "All" again
+    await expect(trigger).toHaveText('All')
   })
 
   test('Errors only checkbox sets level=error in export URL', async ({ page, request }) => {

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -262,6 +262,35 @@ test.describe('Export button in dashboard', () => {
     await expect(trigger).toHaveText('All')
   })
 
+  test('Sort toggle reverses event order', async ({ page, request }) => {
+    await request.post(`${API_BASE}/api/events/reset`)
+    await seedEvents(page, [
+      { type: 'log', payload: { level: 'info', message: 'event-AAA' } },
+      { type: 'log', payload: { level: 'info', message: 'event-BBB' } },
+      { type: 'log', payload: { level: 'info', message: 'event-CCC' } },
+    ])
+    await openDashboard(page)
+
+    // Wait for events to render
+    await expect(page.getByText('event-CCC')).toBeVisible()
+    await expect(page.getByText('event-AAA')).toBeVisible()
+
+    // Record position of AAA relative to CCC before toggling
+    const aaaBefore = await page.getByText('event-AAA').boundingBox()
+    const cccBefore = await page.getByText('event-CCC').boundingBox()
+    const aaaAboveCccBefore = aaaBefore!.y < cccBefore!.y
+
+    // Click the sort toggle
+    await page.getByTestId('sort-order-toggle').click()
+
+    // Positions should be reversed after toggling
+    const aaaAfter = await page.getByText('event-AAA').boundingBox()
+    const cccAfter = await page.getByText('event-CCC').boundingBox()
+    const aaaAboveCccAfter = aaaAfter!.y < cccAfter!.y
+
+    expect(aaaAboveCccAfter).not.toBe(aaaAboveCccBefore)
+  })
+
   test('Errors only checkbox sets level=error in export URL', async ({ page, request }) => {
     await request.post(`${API_BASE}/api/events/reset`)
     await seedEvents(page, [


### PR DESCRIPTION
## Summary
- Replace single-select Type dropdown with multi-select Popover + CheckboxGroup (closes #16)
- Extract duplicated filter logic from App.tsx and SessionDetail.tsx into a shared `useEventFilter` hook
- Add sort order toggle (newest/oldest first) in the FilterBar
- Export button passes comma-separated types to the API (server already supported this)
- **Fix: isolate test database from dev data** — tests were sharing the same `reactotron.db`, causing `POST /api/events/reset` to wipe real session data

## Changes
| File | Change |
|------|--------|
| `dashboard/src/hooks/useEventFilter.ts` | New shared hook for filter state, filtering logic, and sort order |
| `dashboard/src/components/FilterBar.tsx` | Replace `<Select>` with Popover + CheckboxGroup multi-select; add sort toggle button |
| `dashboard/src/App.tsx` | Use `useEventFilter` hook, update export URL builder |
| `dashboard/src/components/SessionDetail.tsx` | Use `useEventFilter` hook |
| `src/index.ts` | Make `OUTPUT_DIR` configurable via env var |
| `playwright.config.ts` | Point test server at `.reactotron-llm-test/` directory |
| `.gitignore` | Add `.reactotron-llm-test/` |
| `tests/export.spec.ts` | Update type filter test + add multi-type, reset, and sort toggle tests |

## Testing
- Updated existing Playwright test "Export passes type filter to URL" for new multi-select interaction
- Added test: select 2+ types, verify export URL contains comma-separated values
- Added test: select types, click Reset, verify filter returns to "All"
- Added test: sort toggle reverses event order
- All 82 tests pass with isolated test database

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: client-side dashboard changes + test infrastructure fix with no production server behavior changes.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)